### PR TITLE
[TASK] Add list of missing teams

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 <section data-background-image="images/TyPower.svg"
                          data-background-size="15%" data-background-position="right">
                     <h2>
-                        Teams presented today
+                        Teams presented today in more detail
                     </h2>
                     <!-- Please keep the team list in alphabetical order. -->
                     <ol>
@@ -838,6 +838,65 @@
                         <h3 class="r-fit-text" style="margin-top: 8rem;">
                             Questions?
                         </h3>
+                    </section>
+                </section>
+
+                <!-- Honourable mention -->
+                <section>
+                    <section data-background-image="images/TyPower.svg"
+                             data-background-size="15%" data-background-position="right">
+                        <h2>Please also have a look at the following teams</h2>
+                        <ul>
+                            <li>
+                                <a href="/community/teams/typo3-development" title="TYPO3 Development">TYPO3 Development</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/academic-committee" title="Academic">Academic</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/accessibility" title="Accessibility">Accessibility</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/communication-coordination" title="Communication Coordination">Communication Coordination</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/community-expansion" title="Community Expansion">Community Expansion</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/content" title="Content">Content</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/structured-content" title="Content Types">Content Types</a>
+                            </li>
+                        </ul>
+                    </section>
+                    <section data-background-image="images/TyPower.svg"
+                             data-background-size="15%" data-background-position="right">
+                        <h2>Please also have a look at the following teams</h2>
+                        <ul>
+                            <li>
+                                <a href="/community/teams/education-certification" title="Education &amp; Certification">Education &amp; Certification</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/marketing" title="Marketing">Marketing</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/ombudsperson" title="Ombudsperson">Ombudsperson</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/typo3-cms-strategy-group" title="TYPO3 CMS Product Strategy Group">TYPO3 CMS Product Strategy Group</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/typo3org" title="typo3.org website">typo3.org website</a>
+                            </li>
+                            <li>
+                                <a href="/community/teams/user-experience-ux" title="User Experience (UX)">User Experience (UX)</a>
+                            </li>
+                        </ul>
+                        <p style="margin-top: 5rem;">
+                            More information about all teams:<br/>
+                            <a href="https://typo3.org/community/teams/">https://typo3.org/community/teams/</a>
+                        </p>
                     </section>
                 </section>
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 <section data-background-image="images/TyPower.svg"
                          data-background-size="15%" data-background-position="right">
                     <h2>
-                        Teams presented today in more detail
+                        Teams presented today
                     </h2>
                     <!-- Please keep the team list in alphabetical order. -->
                     <ol>
@@ -85,7 +85,7 @@
                         </li>
                     </ol>
 
-                    <p style="margin-top: 5rem;">
+                    <p style="margin-top: 3rem;">
                         More information about all teams:<br/>
                         <a href="https://typo3.org/community/teams/">https://typo3.org/community/teams/</a>
                     </p>

--- a/index.html
+++ b/index.html
@@ -845,52 +845,56 @@
                 <section>
                     <section data-background-image="images/TyPower.svg"
                              data-background-size="15%" data-background-position="right">
-                        <h2>Please also have a look at the following teams</h2>
+                        <h2>
+                            Please also have a look at the following teams
+                        </h2>
                         <ul>
                             <li>
-                                <a href="/community/teams/typo3-development" title="TYPO3 Development">TYPO3 Development</a>
+                                <a href="https://typo3.org/community/teams/typo3-development">TYPO3 Development</a>
                             </li>
                             <li>
-                                <a href="/community/teams/academic-committee" title="Academic">Academic</a>
+                                <a href="https://typo3.org/community/teams/academic-committee">Academic</a>
                             </li>
                             <li>
-                                <a href="/community/teams/accessibility" title="Accessibility">Accessibility</a>
+                                <a href="https://typo3.org/community/teams/accessibility">Accessibility</a>
                             </li>
                             <li>
-                                <a href="/community/teams/communication-coordination" title="Communication Coordination">Communication Coordination</a>
+                                <a href="https://typo3.org/community/teams/communication-coordination">Communication Coordination</a>
                             </li>
                             <li>
-                                <a href="/community/teams/community-expansion" title="Community Expansion">Community Expansion</a>
+                                <a href="https://typo3.org/community/teams/community-expansion">Community Expansion</a>
                             </li>
                             <li>
-                                <a href="/community/teams/content" title="Content">Content</a>
+                                <a href="https://typo3.org/community/teams/content">Content</a>
                             </li>
                             <li>
-                                <a href="/community/teams/structured-content" title="Content Types">Content Types</a>
+                                <a href="https://typo3.org/community/teams/structured-content">Content Types</a>
                             </li>
                         </ul>
                     </section>
                     <section data-background-image="images/TyPower.svg"
                              data-background-size="15%" data-background-position="right">
-                        <h2>Please also have a look at the following teams</h2>
+                        <h2>
+                            Please also have a look at the following teams
+                        </h2>
                         <ul>
                             <li>
-                                <a href="/community/teams/education-certification" title="Education &amp; Certification">Education &amp; Certification</a>
+                                <a href="https://typo3.org/community/teams/education-certification">Education &amp; Certification</a>
                             </li>
                             <li>
-                                <a href="/community/teams/marketing" title="Marketing">Marketing</a>
+                                <a href="https://typo3.org/community/teams/marketing">Marketing</a>
                             </li>
                             <li>
-                                <a href="/community/teams/ombudsperson" title="Ombudsperson">Ombudsperson</a>
+                                <a href="https://typo3.org/community/teams/ombudsperson">Ombudsperson</a>
                             </li>
                             <li>
-                                <a href="/community/teams/typo3-cms-strategy-group" title="TYPO3 CMS Product Strategy Group">TYPO3 CMS Product Strategy Group</a>
+                                <a href="https://typo3.org/community/teams/typo3-cms-strategy-group">TYPO3 CMS Product Strategy Group</a>
                             </li>
                             <li>
-                                <a href="/community/teams/typo3org" title="typo3.org website">typo3.org website</a>
+                                <a href="https://typo3.org/community/teams/typo3org">typo3.org website</a>
                             </li>
                             <li>
-                                <a href="/community/teams/user-experience-ux" title="User Experience (UX)">User Experience (UX)</a>
+                                <a href="https://typo3.org/community/teams/user-experience-ux">User Experience (UX)</a>
                             </li>
                         </ul>
                         <p style="margin-top: 5rem;">


### PR DESCRIPTION
So that the list of all official TYPO3 teams remains complete in the slides, there are two more slides at the end of the presentation with a list of the teams not mentioned in detail. Each team links to the team details page on typo3.org.